### PR TITLE
Change provider_asn1 dependency url to https

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {plugins,
  [{provider_asn1,
    {git,
-    "git@github.com:massemanet/provider_asn1",
+    "https://github.com/massemanet/provider_asn1",
     "3873785"}}]}.
 
 {pre_hooks, [{compile, "rebar3 asn compile"}]}.


### PR DESCRIPTION
To ensure that the dependency can be fetched from docker regardless
ssh setup